### PR TITLE
updated public turtlenode.io urls

### DIFF
--- a/turtlecoin-nodes.json
+++ b/turtlecoin-nodes.json
@@ -1,68 +1,28 @@
 {
     "nodes" : [
         {
-            "name": "US-EAST-1",
-            "url": "http://node-1.nyc.turtlenode.io",
+            "name": "US-WEST",
+            "url": "http://us-west.turtlenode.io",
             "port": 11898
         },
-        {
-            "name": "US-EAST-2",
-            "url": "http://node-2.nyc.turtlenode.io",
+         {
+            "name": "US-EAST",
+            "url": "http://us-east.turtlenode.io",
             "port": 11898
         },
-        {
-            "name": "US-EAST-3",
-            "url": "http://node-3.nyc.turtlenode.io",
+         {
+            "name": "EUROPE",
+            "url": "http://europe.turtlenode.io",
             "port": 11898
         },
-        {
-            "name": "US-WEST-1",
-            "url": "http://node-1.sfo.turtlenode.io",
+         {
+            "name": "ASIA",
+            "url": "http://asia.turtlenode.io",
             "port": 11898
         },
-        {
-            "name": "US-WEST-2",
-            "url": "http://node-2.sfo.turtlenode.io",
-            "port": 11898
-        },
-        {
-            "name": "US-WEST-3",
-            "url": "http://node-3.sfo.turtlenode.io",
-            "port": 11898
-        },
-        {
-            "name": "EU-AMS-1",
-            "url": "http://node-1.ams.turtlenode.io",
-            "port": 11898
-        },
-        {
-            "name": "EU-AMS-2",
-            "url": "http://node-2.ams.turtlenode.io",
-            "port": 11898
-        },
-        {
-            "name": "EU-AMS-3",
-            "url": "http://node-3.ams.turtlenode.io",
-            "port": 11898
-        },
-        {
-            "name": "AS-SIN-1",
-            "url": "http://node-1.sin.turtlenode.io",
-            "port": 11898
-        },
-        {
-            "name": "AS-SIN-2",
-            "url": "http://node-2.sin.turtlenode.io",
-            "port": 11898
-        },
-        {
-            "name": "AS-SIN-3",
-            "url": "http://node-3.sin.turtlenode.io",
-            "port": 11898
-        },
-        {
-            "name": "Seed.Turtlenode.Io",
-            "url": "http://seed.turtlenode.io",
+         {
+            "name": "PUBLIC",
+            "url": "http://public.turtlenode.io",
             "port": 11898
         },
         {


### PR DESCRIPTION
based on `Effective 2018-06-16: Public access to the individual nodes is no longer permitted to better control traffic flow and load balancing. Please use one of the region load balancers or the public.turtlenode.io hostname.`

not sure if this is the right thing to do? just learning and bored and want to contribute 😊