### PR TITLE
Update turtlecoin-nodes.json

### DIFF
--- a/turtlecoin-nodes.json
+++ b/turtlecoin-nodes.json
@@ -85,12 +85,6 @@
             "ssl": false
         },
         {
-            "name": "turtlenode.uk",
-            "url": "public.turtlenode.uk",
-            "port": 11898,
-            "ssl": false
-        },
-        {
             "name": "skinner.aus",
             "url": "skinnerturtle.ddns.net",
             "port": 11898,


### PR DESCRIPTION
Remove turtlenode.uk domain.  I think having 2 domains pointing to 1 IP was causing confusion, and didn't look great.