### PR TITLE
Update Node URL - Thingyweb.com (Australia)

### DIFF
--- a/turtlecoin-nodes.json
+++ b/turtlecoin-nodes.json
@@ -37,8 +37,8 @@
       "ssl": false
     },
     {
-      "name": "Australia/Brisbane - Thingyweb.com.au",
-      "url": "trtlnode.thingyweb.com.au",
+      "name": "Australia - Thingyweb.com",
+      "url": "node.turtlecoin.thingyweb.com",
       "port": 11898,
       "ssl": false
     },


### PR DESCRIPTION
Changed from trtlnode.thingyweb.com.au to node.turtlecoin.thingyweb.com