### PR TITLE
Update turtlecoin-nodes.json

### DIFF
--- a/turtlecoin-nodes.json
+++ b/turtlecoin-nodes.json
@@ -97,12 +97,6 @@
       "ssl": false
     },
     {
-      "name": "D. Smasher's Node",
-      "url": "dsmash.turtlenode.online",
-      "port": 11898,
-      "ssl": false
-    },
-    {
       "name": "EU Public Node",
       "url": "crypto-dredge.com",
       "port": 11898,


### PR DESCRIPTION
Removed "dsmash.turtlenode.online" from the list, as it will be shut down on 20th January.