### PR TITLE
Update turtlecoin-nodes.json

### DIFF
--- a/turtlecoin-nodes.json
+++ b/turtlecoin-nodes.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "Canadian Turtle Public Node",
-      "url": "dkc-hvac.com",
+      "url": "mine2.live",
       "port": 11898,
       "ssl": false
     },


### PR DESCRIPTION
changed Canadian Turtle Public Node host from dkc-hvac.com to mine2.live