### PR TITLE
Network7 node subdomain updated

### DIFF
--- a/turtlecoin-nodes.json
+++ b/turtlecoin-nodes.json
@@ -204,6 +204,13 @@
       "cache": false
     },
     {
+      "name": "Network 7 Slow Node - 10 TRTL",
+      "url": "nodes.trtl.nu",
+      "port": 11898,
+      "ssl": false,
+      "cache": false
+    },
+    {
       "name": "Nutmeg Hash - Tokyo 5 TRTL",
       "url": "35.189.150.102",
       "port": 11898,

--- a/turtlecoin-nodes.json
+++ b/turtlecoin-nodes.json
@@ -198,7 +198,7 @@
     },
     {
       "name": "Network 7 Premium Node - 700 TRTL",
-      "url": "node0.turtlecoin.nu",
+      "url": "nodes.turtlecoin.nu",
       "port": 11898,
       "ssl": false,
       "cache": false


### PR DESCRIPTION
Preparation for HA node(s).

node0.turtlecoin.nu is still online so there will be no interruptions for users.